### PR TITLE
Use .PHONY for test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: denylist
+.PHONY: denylist test
 
 default:
 


### PR DESCRIPTION
This will ensure `make test` continues to work even if somebody does a `mkdir test` at some point. Perhaps paranoid, but really the proper way to do this since the `make test` job doesn't create anything called `test` on the filesystem.